### PR TITLE
Fixed some aspect of the visualization component

### DIFF
--- a/src/Visualization/Visualization.jsx
+++ b/src/Visualization/Visualization.jsx
@@ -61,7 +61,6 @@ class Visualization extends React.Component {
   }
 
   render() {
-    // TODO RUBEN FIX THE GRAPH TO BE DISPLAYED WHEN NO DATA IS PROVIDED.
     const { data } = this.props;
     const LONG_PLANNED_PR_COLOR = 'black';
     const QUICKLY_WRITTEN_PR = 'red';
@@ -82,8 +81,8 @@ class Visualization extends React.Component {
         <XYPlot
           width={500}
           height={500}
-          xDomain={[0, processedPRData.largestDayOffsetFromRepoCreation]}
-          yDomain={[minYAxisVal, maxYAxisVal]}
+          xDomain={[0, processedPRData.largestDayOffsetFromRepoCreation || 10]}
+          yDomain={[minYAxisVal || 0, maxYAxisVal || 10]}
         >
           <XAxis title="Days since repository creation" />
           <YAxis title="Number of bugs caused" position="middle" />

--- a/src/Visualization/Visualization.jsx
+++ b/src/Visualization/Visualization.jsx
@@ -16,7 +16,6 @@ class Visualization extends React.Component {
   }
 
   processDataForGraph = (data) => {
-    // TODO RUBEN Add check to not use those data points where the bug count = -1.
     const NUM_OF_MILLISECONDS_IN_A_DAY = 86400000;
     /**
      * Process all PRs data by normalizing the creation date values to display on the graph as well as
@@ -31,31 +30,35 @@ class Visualization extends React.Component {
     for (let i = 0; i < data.plannedPRs.length; i++) {
       let currentPRDayOffsetFromRepoCreation = ((new Date(data.plannedPRs[i].datePRCreated)).getTime() - repoCreationMilliseconds) / NUM_OF_MILLISECONDS_IN_A_DAY;
       let currentBugCount = data.plannedPRs[i].numberOfBugs;
-      if (currentPRDayOffsetFromRepoCreation > processedPRData.largestDayOffsetFromRepoCreation) {
-        processedPRData.largestDayOffsetFromRepoCreation = currentPRDayOffsetFromRepoCreation;
+      if (currentBugCount !== -1) {
+        if (currentPRDayOffsetFromRepoCreation > processedPRData.largestDayOffsetFromRepoCreation) {
+          processedPRData.largestDayOffsetFromRepoCreation = currentPRDayOffsetFromRepoCreation;
+        }
+        if (currentPRDayOffsetFromRepoCreation > processedPRData.largestPlannedPRsDayOffset) {
+          processedPRData.largestPlannedPRsDayOffset = currentPRDayOffsetFromRepoCreation;
+        }
+        if (currentBugCount > processedPRData.highestBugCount) {
+          processedPRData.highestBugCount = currentBugCount;
+        }
+        processedPRData.plannedPRs[i] = { x: currentPRDayOffsetFromRepoCreation, y: currentBugCount };
       }
-      if (currentPRDayOffsetFromRepoCreation > processedPRData.largestPlannedPRsDayOffset) {
-        processedPRData.largestPlannedPRsDayOffset = currentPRDayOffsetFromRepoCreation;
-      }
-      if (currentBugCount > processedPRData.highestBugCount) {
-        processedPRData.highestBugCount = currentBugCount;
-      }
-      processedPRData.plannedPRs[i] = { x: currentPRDayOffsetFromRepoCreation, y: currentBugCount };
     }
     // Process the fast PRs:
     for (let i = 0; i < data.fastPRs.length; i++) {
       let currentPRDayOffsetFromRepoCreation = ((new Date(data.fastPRs[i].datePRCreated)).getTime() - repoCreationMilliseconds) / NUM_OF_MILLISECONDS_IN_A_DAY;
       let currentBugCount = data.fastPRs[i].numberOfBugs;
-      if (currentPRDayOffsetFromRepoCreation > processedPRData.largestDayOffsetFromRepoCreation) {
-        processedPRData.largestDayOffsetFromRepoCreation = currentPRDayOffsetFromRepoCreation;
+      if (currentBugCount !== -1) {
+        if (currentPRDayOffsetFromRepoCreation > processedPRData.largestDayOffsetFromRepoCreation) {
+          processedPRData.largestDayOffsetFromRepoCreation = currentPRDayOffsetFromRepoCreation;
+        }
+        if (currentPRDayOffsetFromRepoCreation > processedPRData.largestFastPRsDayOffset) {
+          processedPRData.largestFastPRsDayOffset = currentPRDayOffsetFromRepoCreation;
+        }
+        if (currentBugCount > processedPRData.highestBugCount) {
+          processedPRData.highestBugCount = currentBugCount;
+        }
+        processedPRData.fastPRs[i] = { x: currentPRDayOffsetFromRepoCreation, y: currentBugCount };
       }
-      if (currentPRDayOffsetFromRepoCreation > processedPRData.largestFastPRsDayOffset) {
-        processedPRData.largestFastPRsDayOffset = currentPRDayOffsetFromRepoCreation;
-      }
-      if (currentBugCount > processedPRData.highestBugCount) {
-        processedPRData.highestBugCount = currentBugCount;
-      }
-      processedPRData.fastPRs[i] = { x: currentPRDayOffsetFromRepoCreation, y: currentBugCount };
     }
     return processedPRData;
   }

--- a/src/Visualization/Visualization.jsx
+++ b/src/Visualization/Visualization.jsx
@@ -16,12 +16,16 @@ class Visualization extends React.Component {
   }
 
   processDataForGraph = (data) => {
+    // TODO RUBEN Add check to not use those data points where the bug count = -1.
     const NUM_OF_MILLISECONDS_IN_A_DAY = 86400000;
     /**
      * Process all PRs data by normalizing the creation date values to display on the graph as well as
      * finding the largest values for each axis.
      */
-    let processedPRData = { plannedPRs: [], fastPRs: [], largestDayOffsetFromRepoCreation: 0, highestBugCount: 0 };
+    let processedPRData = {
+      plannedPRs: [], fastPRs: [], largestDayOffsetFromRepoCreation: 0, highestBugCount: 0,
+      largestPlannedPRsDayOffset: 0, largestFastPRsDayOffset: 0
+    };
     let repoCreationMilliseconds = (new Date(data.dateRepoCreated)).getTime();
     // Process the planned PRs:
     for (let i = 0; i < data.plannedPRs.length; i++) {
@@ -29,6 +33,9 @@ class Visualization extends React.Component {
       let currentBugCount = data.plannedPRs[i].numberOfBugs;
       if (currentPRDayOffsetFromRepoCreation > processedPRData.largestDayOffsetFromRepoCreation) {
         processedPRData.largestDayOffsetFromRepoCreation = currentPRDayOffsetFromRepoCreation;
+      }
+      if (currentPRDayOffsetFromRepoCreation > processedPRData.largestPlannedPRsDayOffset) {
+        processedPRData.largestPlannedPRsDayOffset = currentPRDayOffsetFromRepoCreation;
       }
       if (currentBugCount > processedPRData.highestBugCount) {
         processedPRData.highestBugCount = currentBugCount;
@@ -42,6 +49,9 @@ class Visualization extends React.Component {
       if (currentPRDayOffsetFromRepoCreation > processedPRData.largestDayOffsetFromRepoCreation) {
         processedPRData.largestDayOffsetFromRepoCreation = currentPRDayOffsetFromRepoCreation;
       }
+      if (currentPRDayOffsetFromRepoCreation > processedPRData.largestFastPRsDayOffset) {
+        processedPRData.largestFastPRsDayOffset = currentPRDayOffsetFromRepoCreation;
+      }
       if (currentBugCount > processedPRData.highestBugCount) {
         processedPRData.highestBugCount = currentBugCount;
       }
@@ -51,6 +61,7 @@ class Visualization extends React.Component {
   }
 
   render() {
+    // TODO RUBEN FIX THE GRAPH TO BE DISPLAYED WHEN NO DATA IS PROVIDED.
     const { data } = this.props;
     const LONG_PLANNED_PR_COLOR = 'black';
     const QUICKLY_WRITTEN_PR = 'red';
@@ -61,8 +72,8 @@ class Visualization extends React.Component {
     let yValuesInBestFitLines = [
       fastPRsBestFitLine(0),
       plannedLongPRsBestFitLine(0),
-      plannedLongPRsBestFitLine(processedPRData.largestDayOffsetFromRepoCreation),
-      fastPRsBestFitLine(processedPRData.largestDayOffsetFromRepoCreation)];
+      plannedLongPRsBestFitLine(processedPRData.largestPlannedPRsDayOffset),
+      fastPRsBestFitLine(processedPRData.largestFastPRsDayOffset)];
     let maxYAxisVal = Math.max(...yValuesInBestFitLines),
       minYAxisVal = Math.min(...yValuesInBestFitLines);
 
@@ -88,7 +99,7 @@ class Visualization extends React.Component {
             color={LONG_PLANNED_PR_COLOR}
             data={[
               { x: 0, y: plannedLongPRsBestFitLine(0) },
-              { x: processedPRData.largestDayOffsetFromRepoCreation, y: plannedLongPRsBestFitLine(processedPRData.largestDayOffsetFromRepoCreation) },
+              { x: processedPRData.largestPlannedPRsDayOffset, y: plannedLongPRsBestFitLine(processedPRData.largestPlannedPRsDayOffset) },
             ]}
           />
           <MarkSeries
@@ -101,7 +112,7 @@ class Visualization extends React.Component {
             color={QUICKLY_WRITTEN_PR}
             data={[
               { x: 0, y: fastPRsBestFitLine(0) },
-              { x: processedPRData.largestDayOffsetFromRepoCreation, y: fastPRsBestFitLine(processedPRData.largestDayOffsetFromRepoCreation) },
+              { x: processedPRData.largestFastPRsDayOffset, y: fastPRsBestFitLine(processedPRData.largestFastPRsDayOffset) },
             ]}
           />
         </XYPlot>


### PR DESCRIPTION
- Added default data for the graph when no repo has been analyzed yet.
- Improved the drawing of the best fit line so each line only gets as far as the latest data point in the set does.
- Added check based on Candice's feedback on how some PR data points might have a bug count of -1, and how they should no be drawn.